### PR TITLE
Fix with Glob where path provided has wild card and using backward slash

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,27 +17,37 @@ stages:
         sourceDirectory: 'bicep_files/'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (defaults with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - backward slash)'
       inputs:
-        sourceDirectory: '**/**.bicep'
+        sourceDirectory: 'bicep_files\*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - forward slash)'
+      inputs:
+        sourceDirectory: '**/*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - backward slash)'
+      inputs:
+        sourceDirectory: '**\*.bicep'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
         outputDirectory: 'bicep_files/out'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
         stdout: true
 
     - task: BicepBuild@0
@@ -70,7 +80,7 @@ stages:
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test 2'
       inputs:
-        sourceDirectory: 'bicep files/**.bicep'
+        sourceDirectory: 'bicep files/*.bicep'
 
     - script: 'ls -laR "bicep files"'
       displayName: 'List source and generated files'
@@ -81,22 +91,27 @@ stages:
         sourceDirectory: 'arm_templates/'
 
     - task: BicepDecompile@0
-      displayName: 'Decompile Sample .json files test (defaults with glob)'
+      displayName: 'Decompile Sample .json files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
+
+    - task: BicepDecompile@0
+      displayName: 'Decompile Sample .json files test (defaults with glob - backward slash)'
+      inputs:
+        sourceDirectory: 'arm_templates\*.json'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         outputDirectory: 'arm_templates/out'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         stdout: true
 
     - task: BicepDecompile@0
@@ -129,7 +144,7 @@ stages:
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test 2'
       inputs:
-        sourceDirectory: 'arm templates/**.json'
+        sourceDirectory: 'arm templates/*.json'
 
     - script: 'ls -laR "arm templates"'
       displayName: 'List source and generated files'
@@ -149,27 +164,37 @@ stages:
         sourceDirectory: 'bicep_files/'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (defaults with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - backward slash)'
       inputs:
-        sourceDirectory: '**/**.bicep'
+        sourceDirectory: 'bicep_files\*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - forward slash)'
+      inputs:
+        sourceDirectory: '**/*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - backward slash)'
+      inputs:
+        sourceDirectory: '**\*.bicep'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files\**.bicep'
+        sourceDirectory: 'bicep_files\*.bicep'
         outputDirectory: 'bicep_files\out'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files\**.bicep'
+        sourceDirectory: 'bicep_files\*.bicep'
         stdout: true
 
     - task: BicepBuild@0
@@ -202,7 +227,7 @@ stages:
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test 2'
       inputs:
-        sourceDirectory: 'bicep files/**.bicep'
+        sourceDirectory: 'bicep files/*.bicep'
 
     - script: 'dir /s "bicep files"'
       displayName: 'List source and generated files'
@@ -213,22 +238,27 @@ stages:
         sourceDirectory: 'arm_templates/'
 
     - task: BicepDecompile@0
-      displayName: 'Decompile Sample .json files test (defaults with glob)'
+      displayName: 'Decompile Sample .json files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
+
+    - task: BicepDecompile@0
+      displayName: 'Decompile Sample .json files test (defaults with glob - backward slash)'
+      inputs:
+        sourceDirectory: 'arm_templates\*.json'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         outputDirectory: 'arm_templates/out'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         stdout: true
 
     - task: BicepDecompile@0
@@ -261,7 +291,7 @@ stages:
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test 2'
       inputs:
-        sourceDirectory: 'arm templates/**.json'
+        sourceDirectory: 'arm templates/*.json'
 
     - script: 'dir /s "arm templates"'
       displayName: 'List source and generated files'
@@ -281,27 +311,37 @@ stages:
         sourceDirectory: 'bicep_files/'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (defaults with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
 
     - task: BicepBuild@0
-      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob)'
+      displayName: 'Compile Sample .bicep files test (defaults with glob - backward slash)'
       inputs:
-        sourceDirectory: '**/**.bicep'
+        sourceDirectory: 'bicep_files\*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - forward slash)'
+      inputs:
+        sourceDirectory: '**/*.bicep'
+
+    - task: BicepBuild@0
+      displayName: 'Compile Sample .bicep files test (all in entire directory tree with glob - backward slash)'
+      inputs:
+        sourceDirectory: '**\*.bicep'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
         outputDirectory: 'bicep_files/out'
 
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'bicep_files/**.bicep'
+        sourceDirectory: 'bicep_files/*.bicep'
         stdout: true
 
     - task: BicepBuild@0
@@ -334,7 +374,7 @@ stages:
     - task: BicepBuild@0
       displayName: 'Compile Sample .bicep files test 2'
       inputs:
-        sourceDirectory: 'bicep files/**.bicep'
+        sourceDirectory: 'bicep files/*.bicep'
 
     - script: 'ls -laR "bicep files"'
       displayName: 'List source and generated files'
@@ -345,22 +385,27 @@ stages:
         sourceDirectory: 'arm_templates/'
 
     - task: BicepDecompile@0
-      displayName: 'Decompile Sample .json files test (defaults with glob)'
+      displayName: 'Decompile Sample .json files test (defaults with glob - forward slash)'
       inputs:
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
+
+    - task: BicepDecompile@0
+      displayName: 'Decompile Sample .json files test (defaults with glob - backward slash)'
+      inputs:
+        sourceDirectory: 'arm_templates\*.json'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with output directory)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         outputDirectory: 'arm_templates/out'
 
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test (with stdout output)'
       inputs:
         process: 'multiple'
-        sourceDirectory: 'arm_templates/**.json'
+        sourceDirectory: 'arm_templates/*.json'
         stdout: true
 
     - task: BicepDecompile@0
@@ -393,7 +438,7 @@ stages:
     - task: BicepDecompile@0
       displayName: 'Decompile Sample .json files test 2'
       inputs:
-        sourceDirectory: 'arm templates/**.json'
+        sourceDirectory: 'arm templates/*.json'
 
     - script: 'ls -laR "arm templates"'
       displayName: 'List source and generated files'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,9 @@
         "axios": "^0.27.2",
         "azure-pipelines-task-lib": "^4.2.0",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
-        "glob": "^8.1.0"
+        "glob": "^9.3.4"
       },
       "devDependencies": {
-        "@types/glob": "^8.0.1",
         "@types/jest": "^29.4.0",
         "@types/node": "^18.13.0",
         "@types/q": "^1.5.5",
@@ -24,6 +23,7 @@
         "eslint": "^8.34.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "glob": "^9.3.4",
         "husky": "^8.0.3",
         "jest": "^29.4.2",
         "lint-staged": "^13.1.1",
@@ -1235,16 +1235,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.1.tgz",
-      "integrity": "sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1292,12 +1282,6 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3122,18 +3106,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.4.tgz",
+      "integrity": "sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3155,19 +3139,24 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.3.tgz",
+      "integrity": "sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -4762,6 +4751,15 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
@@ -4965,6 +4963,31 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-scurry": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
+      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7064,16 +7087,6 @@
         "@types/node": "*"
       }
     },
-    "@types/glob": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.1.tgz",
-      "integrity": "sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -7121,12 +7134,6 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
-    },
-    "@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "@types/node": {
@@ -8453,29 +8460,31 @@
       "dev": true
     },
     "glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.4.tgz",
+      "integrity": "sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.3.tgz",
+          "integrity": "sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -9675,6 +9684,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true
+    },
     "mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
@@ -9827,6 +9842,24 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-scurry": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
+      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "axios": "^0.27.2",
     "azure-pipelines-task-lib": "^4.2.0",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
-    "glob": "^8.1.0"
+    "glob": "^9.3.4"
   },
   "devDependencies": {
-    "@types/glob": "^8.0.1",
+    "glob": "^9.3.4",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.13.0",
     "@types/q": "^1.5.5",

--- a/src/decompile/common/fileUtils.ts
+++ b/src/decompile/common/fileUtils.ts
@@ -1,13 +1,16 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { glob } from 'glob';
+import * as glob from 'glob';
 
 export function getFilesList(directory: string): string[] {
     let directoryToGetFiles: string = directory;
+
+    directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
     if (!glob.hasMagic(directoryToGetFiles)) {
         directoryToGetFiles = path.join(directoryToGetFiles, '**');
+        directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
     }
-    directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
+    
     const allFiles = glob.sync(directoryToGetFiles, { nodir: true });
     return allFiles.filter((file) => file.endsWith('.json'));
 }

--- a/src/run/common/fileUtils.ts
+++ b/src/run/common/fileUtils.ts
@@ -1,13 +1,16 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { glob } from 'glob';
+import * as glob from 'glob';
 
 export function getFilesList(directory: string): string[] {
     let directoryToGetFiles: string = directory;
+    
+    directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
     if (!glob.hasMagic(directoryToGetFiles)) {
         directoryToGetFiles = path.join(directoryToGetFiles, '**');
+        directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
     }
-    directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');
+
     return glob.sync(directoryToGetFiles, { nodir: true });
 }
 

--- a/test/decompile/common/fileUtils.spec.ts
+++ b/test/decompile/common/fileUtils.spec.ts
@@ -29,7 +29,7 @@ function restoreMocks() {
 describe('getFilesList perform valid actions', () => {
     afterEach(() => restoreMocks());
 
-    test('if path has not wildcards', () => {
+    test('if path has no wildcards - Forward Slash', () => {
         prepareMocks();
 
         getFilesList('./arm_templates');
@@ -38,10 +38,28 @@ describe('getFilesList perform valid actions', () => {
         expect(globSyncMock).toHaveBeenCalledWith('arm_templates/**', { nodir: true });
     });
 
-    test('if path has wildcards', () => {
+    test('if path has not wildcards - Backward Slash', () => {
+        prepareMocks();
+
+        getFilesList('.\\arm_templates');
+        expect(globHasMagicMock).toHaveBeenCalled();
+        expect(pathJoinMock).toHaveBeenCalled();
+        expect(globSyncMock).toHaveBeenCalledWith('arm_templates/**', { nodir: true });
+    });
+
+    test('if path has wildcards - Forward Slash', () => {
         prepareMocks();
 
         getFilesList('./arm_templates/*.json');
+        expect(globHasMagicMock).toHaveBeenCalled();
+        expect(pathJoinMock).not.toHaveBeenCalled();
+        expect(globSyncMock).toHaveBeenCalledWith('./arm_templates/*.json', { nodir: true });
+    });
+
+    test('if path has wildcards - Backward Slash', () => {
+        prepareMocks();
+
+        getFilesList('.\\arm_templates\\*.json');
         expect(globHasMagicMock).toHaveBeenCalled();
         expect(pathJoinMock).not.toHaveBeenCalled();
         expect(globSyncMock).toHaveBeenCalledWith('./arm_templates/*.json', { nodir: true });

--- a/test/run/common/fileUtils.spec.ts
+++ b/test/run/common/fileUtils.spec.ts
@@ -29,7 +29,7 @@ function restoreMocks() {
 describe('getFilesList perform valid actions', () => {
     afterEach(() => restoreMocks());
 
-    test('if path has not wildcards', () => {
+    test('if path has no wildcards - forward slash', () => {
         prepareMocks();
 
         getFilesList('./bicep_files');
@@ -38,10 +38,28 @@ describe('getFilesList perform valid actions', () => {
         expect(globSyncMock).toHaveBeenCalledWith('bicep_files/**', { nodir: true });
     });
 
-    test('if path has wildcards', () => {
+    test('if path has no wildcards - back slash', () => {
+        prepareMocks();
+
+        getFilesList('.\\bicep_files');
+        expect(globHasMagicMock).toHaveBeenCalled();
+        expect(pathJoinMock).toHaveBeenCalled();
+        expect(globSyncMock).toHaveBeenCalledWith('bicep_files/**', { nodir: true });
+    });
+
+    test('if path has wildcards - forward slash', () => {
         prepareMocks();
 
         getFilesList('./bicep_files/*.bicep');
+        expect(globHasMagicMock).toHaveBeenCalled();
+        expect(pathJoinMock).not.toHaveBeenCalled();
+        expect(globSyncMock).toHaveBeenCalledWith('./bicep_files/*.bicep', { nodir: true });
+    });
+
+    test('if path has wildcards - back slash', () => {
+        prepareMocks();
+
+        getFilesList('.\\bicep_files\\*.bicep');
         expect(globHasMagicMock).toHaveBeenCalled();
         expect(pathJoinMock).not.toHaveBeenCalled();
         expect(globSyncMock).toHaveBeenCalledWith('./bicep_files/*.bicep', { nodir: true });


### PR DESCRIPTION
If a path specified with backward slashes, wild card and file type such as: `.\test\*.bicep`; Glob will use the backward slash as an escape character to the wildcard * leaving the path to remain as `.\test\.bicep` when checking for hasMagic; This results in the path being amended to:` .\test\*.bicep**`
- this will then find no bicep/json files to buid/decompile

Fixed using the same directory replacement line used further below in the fileUtils.ts:
- directoryToGetFiles = directoryToGetFiles.replace(/\\/g, '/');

Verifications:
Amended jest tests
Amended Yaml pipeline